### PR TITLE
Removed watch flag

### DIFF
--- a/flannel/package.json
+++ b/flannel/package.json
@@ -91,7 +91,7 @@
     "start": "node start.js",
     "local-start": "PORT=4000 node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "jest --forceExit --detectOpenHandles --watch",
+    "test": "jest --forceExit --detectOpenHandles",
     "eject": "react-scripts eject",
     "test:ci": "npm run test -- --coverage --ci --testResultsProcessor=\"jest-junit\"",
     "jsdoc": "jsdoc -c jsdoc.json"


### PR DESCRIPTION
This PR removes the watch flag from our call to npm test so we can resolve our Travis CI build stall